### PR TITLE
chore: update keyless SDK to version 5.0.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,11 +7,15 @@ def load_env_file(filename)
       ENV[key] = value if key && value
     end
   else
-    puts "#{filename} file not found!"
+    puts "#{filename} file not found. Please create one based on cloudsmith.template.properties"
   end
 end
 
 load_env_file('cloudsmith.properties')
+
+unless ENV['cloudsmithTokenPartners']
+  raise "Missing required environment variable: cloudsmithTokenPartners. Are you sure you created a cloudsmith.properties file based on the cloudsmith.template.properties file?"
+end
 
 source 'https://cdn.cocoapods.org/'
 source 'https://dl.cloudsmith.io/' + ENV['cloudsmithTokenPartners'] +'/keyless/partners/cocoapods/index.git'
@@ -19,7 +23,7 @@ source 'https://dl.cloudsmith.io/' + ENV['cloudsmithTokenPartners'] +'/keyless/p
 
 target 'ScenarioDeveloperQuickstart' do
   use_frameworks!
-  pod 'KeylessSDK', '4.7.4'
+  pod 'KeylessSDK', '5.0.1'
 end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - KeylessSDK (4.7.4)
+  - KeylessSDK (5.0.1)
 
 DEPENDENCIES:
-  - KeylessSDK (= 4.7.4)
+  - KeylessSDK (= 5.0.1)
 
 SPEC REPOS:
   https://dl.cloudsmith.io/iDuTV6v7r8q5wfaI/keyless/partners/cocoapods/index.git:
     - KeylessSDK
 
 SPEC CHECKSUMS:
-  KeylessSDK: 052b2316ca2c376909ab858611c52141f297658f
+  KeylessSDK: 53d81ccb0e42a58267a4a2a2faf21c3b7f82a01d
 
-PODFILE CHECKSUM: aae2847ef9460fd3e4496474df704b1280cdf13e
+PODFILE CHECKSUM: a9cf787ee780a48859b4b6927c01fcaacf0add5c
 
 COCOAPODS: 1.16.2

--- a/ScenarioDeveloperQuickstart.xcodeproj/project.pbxproj
+++ b/ScenarioDeveloperQuickstart.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		DABF991AC202D995C3C87C72 /* Pods_ScenarioDeveloperQuickstart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61480C4262555AB7AF649A82 /* Pods_ScenarioDeveloperQuickstart.framework */; };
+		29024B55227171F1865BEE1F /* Pods_ScenarioDeveloperQuickstart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 973FF4638A33B2B19DB41A30 /* Pods_ScenarioDeveloperQuickstart.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -21,12 +21,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0D39876285D00131092D5CEF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScenarioDeveloperQuickstart.release.xcconfig"; path = "Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart.release.xcconfig"; sourceTree = "<group>"; };
+		0E8F36D89C1EE7A0D611F9BF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScenarioDeveloperQuickstart.release.xcconfig"; path = "Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart.release.xcconfig"; sourceTree = "<group>"; };
 		53F5ACD02D11C477002FAB08 /* ScenarioDeveloperQuickstart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ScenarioDeveloperQuickstart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		53F5ACE02D11C47C002FAB08 /* ScenarioDeveloperQuickstartTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScenarioDeveloperQuickstartTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		61480C4262555AB7AF649A82 /* Pods_ScenarioDeveloperQuickstart.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScenarioDeveloperQuickstart.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		86CFC92B6773F32F573BD930 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScenarioDeveloperQuickstart.debug.xcconfig"; path = "Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
-		8A38DA252D494C9B0039AF0B /* keys.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = keys.template.xcconfig; sourceTree = "<group>"; };
+		973FF4638A33B2B19DB41A30 /* Pods_ScenarioDeveloperQuickstart.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScenarioDeveloperQuickstart.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D75B8D9F0E86CF7E3C5B56C3 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ScenarioDeveloperQuickstart.debug.xcconfig"; path = "Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -60,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DABF991AC202D995C3C87C72 /* Pods_ScenarioDeveloperQuickstart.framework in Frameworks */,
+				29024B55227171F1865BEE1F /* Pods_ScenarioDeveloperQuickstart.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,8 +80,7 @@
 				53F5ACE32D11C47C002FAB08 /* ScenarioDeveloperQuickstartTests */,
 				53F5ACD12D11C477002FAB08 /* Products */,
 				6C4D6BF6B14CDD6F6399F6AE /* Pods */,
-				8A38DA252D494C9B0039AF0B /* keys.template.xcconfig */,
-				FCB6A8459819B9F5A6C91A70 /* Frameworks */,
+				70C683E99E91904632CCFEF5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -98,16 +96,16 @@
 		6C4D6BF6B14CDD6F6399F6AE /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				86CFC92B6773F32F573BD930 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */,
-				0D39876285D00131092D5CEF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */,
+				D75B8D9F0E86CF7E3C5B56C3 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */,
+				0E8F36D89C1EE7A0D611F9BF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		FCB6A8459819B9F5A6C91A70 /* Frameworks */ = {
+		70C683E99E91904632CCFEF5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				61480C4262555AB7AF649A82 /* Pods_ScenarioDeveloperQuickstart.framework */,
+				973FF4638A33B2B19DB41A30 /* Pods_ScenarioDeveloperQuickstart.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -119,11 +117,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 53F5ACF42D11C47C002FAB08 /* Build configuration list for PBXNativeTarget "ScenarioDeveloperQuickstart" */;
 			buildPhases = (
-				AA8C42705BD5C981E427E153 /* [CP] Check Pods Manifest.lock */,
+				8793926E3AE78A689E9474C8 /* [CP] Check Pods Manifest.lock */,
 				53F5ACCC2D11C477002FAB08 /* Sources */,
 				53F5ACCD2D11C477002FAB08 /* Frameworks */,
 				53F5ACCE2D11C477002FAB08 /* Resources */,
-				6EE98E950C498A90C9401E4E /* [CP] Embed Pods Frameworks */,
+				F18B8214A28A77481CC36765 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -215,24 +213,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6EE98E950C498A90C9401E4E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AA8C42705BD5C981E427E153 /* [CP] Check Pods Manifest.lock */ = {
+		8793926E3AE78A689E9474C8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -252,6 +233,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F18B8214A28A77481CC36765 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ScenarioDeveloperQuickstart/Pods-ScenarioDeveloperQuickstart-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -408,7 +406,7 @@
 		};
 		53F5ACF52D11C47C002FAB08 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86CFC92B6773F32F573BD930 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */;
+			baseConfigurationReference = D75B8D9F0E86CF7E3C5B56C3 /* Pods-ScenarioDeveloperQuickstart.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -441,7 +439,7 @@
 		};
 		53F5ACF62D11C47C002FAB08 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D39876285D00131092D5CEF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */;
+			baseConfigurationReference = 0E8F36D89C1EE7A0D611F9BF /* Pods-ScenarioDeveloperQuickstart.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/ScenarioDeveloperQuickstart/Info.plist
+++ b/ScenarioDeveloperQuickstart/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
-	<string></string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>HOST</key>

--- a/ScenarioDeveloperQuickstart/KeylessWrapper.swift
+++ b/ScenarioDeveloperQuickstart/KeylessWrapper.swift
@@ -39,7 +39,7 @@ class KeylessWrapper {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.main.async {
                 
-                Keyless.enroll(configuration: enrollConfig, onProgress: nil) { result in
+                Keyless.enroll(configuration: enrollConfig) { result in
                     switch result {
                     case .success(_):
                         continuation.resume(returning: ())

--- a/ScenarioDeveloperQuickstart/README.md
+++ b/ScenarioDeveloperQuickstart/README.md
@@ -47,15 +47,15 @@ Make sure to remove any trialing slash from the Keyless host
 - OK     ->  `https://host.keyless.technology`
 - NOT OK ->  `https://host.keyless.technology/`
 
-Now add the keys.xcconfig as configuration for debug and release under `Project -> ScenarioDeveloperQuickstart -> Info -> Configurations`. Then add the `API_KEY` and `HOST` to your `Info.plist`
+Now add the keys.xcconfig as configuration for debug and release under `Project -> ScenarioDeveloperQuickstart -> Info -> Configurations`. 
+
+We already prepared the code to retrieve the `API_KEY` and `HOST` from the `keys.xcconfig` you just created, double check that your `Info.plist` contains the following:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
-	<string></string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>HOST</key>


### PR DESCRIPTION
### This PR adds:
update the Keyless SDK to version 5.0.1

### More Details
Also update dependencies that are out of date

### Pair up with
- [x] Lone
- [ ] With @

### Security
Does this PR change code that manipulates seed, private keys, or other secrets?
- [ ] Yes, implications already discussed with the appropriate figure
- [x] No

### Tests
- [ ] Run/Fixed existing tests
- [ ] Add new tests
- [x] No new tests
