### PR TITLE
MOB-3371: update keyless SDK to version 5.5.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ source 'https://dl.cloudsmith.io/' + ENV['cloudsmithTokenPartners'] +'/keyless/p
 
 target 'ScenarioDeveloperQuickstart' do
   use_frameworks!
-  pod 'keyless-mobile-sdk', '5.4.0'
+  pod 'keyless-mobile-sdk', '5.5.0'
 end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - keyless-mobile-sdk (5.4.0)
+  - keyless-mobile-sdk (5.5.0)
 
 DEPENDENCIES:
-  - keyless-mobile-sdk (= 5.4.0)
+  - keyless-mobile-sdk (= 5.5.0)
 
 SPEC REPOS:
   https://dl.cloudsmith.io/YOUR_CLOUDSMITH_TOKEN/keyless/partners/cocoapods/index.git:
     - keyless-mobile-sdk
 
 SPEC CHECKSUMS:
-  keyless-mobile-sdk: 4db19a3d595bb2bae5d35eb5de0537d13391e7d5
+  keyless-mobile-sdk: 0ff2df9676c8496f68d890843640578d6b17bc39
 
-PODFILE CHECKSUM: 6c4572b78695418123cbbf324182092ae9d6df7d
+PODFILE CHECKSUM: ee4eb5426bd0531b1418caa47214bddf41020799
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
### This PR adds:
update the Keyless SDK to version 5.5.0

### More Details
N.A.

### Pair up with
- [x] Lone
- [ ] With @

### Security
Does this PR change code that manipulates seed, private keys, or other secrets?
- [ ] Yes, implications already discussed with the appropriate figure
- [x] No

### Tests
- [ ] Run/Fixed existing tests
- [ ] Add new tests
- [x] No new tests
